### PR TITLE
fix to close only unpinned right sidebar windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,9 @@ async function toggleWindowCollapse() {
 }
 
 async function loopWindows(extensionAPI) {
-  let sidebar = window.roamAlphaAPI.ui.rightSidebar.getWindows();
+  let sidebar = window.roamAlphaAPI.ui.rightSidebar.getWindows()
+                  // only remove unpinned sidebar windows
+                  .filter(w => !(w["pinned?"] || w["pinned-to-top?"]));
   if (extensionAPI.settings.get('sidebar-confirm')) {
     renderSimpleAlert({
       content:
@@ -51,6 +53,7 @@ async function loopWindows(extensionAPI) {
           // console.log(sidebar[i])
           removeWindow(sidebar[i])
         }
+        window.roamAlphaAPI.ui.rightSidebar.close();
       },
       onCancel: () => {
         // do nothing
@@ -60,6 +63,7 @@ async function loopWindows(extensionAPI) {
     for (let i = 0; i < sidebar.length; i++) {
       removeWindow(sidebar[i])
     }
+    window.roamAlphaAPI.ui.rightSidebar.close();
   }
 }
 


### PR DESCRIPTION
hey @8bitgentleman 

We're going to be making a change in Roam soon where if a pinned window is closed, it will not "resurrect" later

This change would lead to difference in behavior of the "Clear Sidebar" extension (where people are probably used to their pinned windows coming back)

This PR will make it such that the behavior remains unchanged

I tested both in prod (roamresearch.com) and in the new deployment: https://relemma-git-feat-pin-top-of-sidebar.roamresearch.com/ . So I think this fix should be okay